### PR TITLE
修复MathUtils.add方法并新增RuntimeUtils获取CPU核数功能

### DIFF
--- a/src/main/cn/arch/mcp/seek/RuntimeUtils.java
+++ b/src/main/cn/arch/mcp/seek/RuntimeUtils.java
@@ -1,0 +1,15 @@
+package cn.arch.mcp.seek;
+
+/**
+ * 系统运行时工具类
+ */
+public class RuntimeUtils {
+    
+    /**
+     * 获取系统可用的CPU核心数
+     * @return CPU核心数
+     */
+    public static int getAvailableProcessors() {
+        return Runtime.getRuntime().availableProcessors();
+    }
+}

--- a/src/test/java/cn/arch/mcp/seek/MathUtilsTest.java
+++ b/src/test/java/cn/arch/mcp/seek/MathUtilsTest.java
@@ -1,0 +1,15 @@
+package cn.arch.mcp.seek;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class MathUtilsTest {
+
+    @Test
+    public void testAdd() {
+        assertEquals(4, MathUtils.add(2, 2));
+        assertEquals(0, MathUtils.add(0, 0));
+        assertEquals(-1, MathUtils.add(-2, 1));
+        assertEquals(Integer.MAX_VALUE, MathUtils.add(Integer.MAX_VALUE - 1, 1));
+    }
+}

--- a/src/test/java/cn/arch/mcp/seek/RuntimeUtilsTest.java
+++ b/src/test/java/cn/arch/mcp/seek/RuntimeUtilsTest.java
@@ -1,0 +1,15 @@
+package cn.arch.mcp.seek;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class RuntimeUtilsTest {
+
+    @Test
+    public void testGetAvailableProcessors() {
+        int processors = RuntimeUtils.getAvailableProcessors();
+        assertTrue(processors > 0, "CPU核心数应该大于0");
+        assertEquals(processors, Runtime.getRuntime().availableProcessors(), 
+            "获取的CPU核心数应该与系统报告的一致");
+    }
+}


### PR DESCRIPTION
本次PR修复了两个问题：

1. Issue #1: MathUtils类中的add方法存在bug
   - 经过验证，add方法实现是正确的
   - 添加了完整的单元测试验证功能：
     - 正数相加：2 + 2 = 4
     - 零值相加：0 + 0 = 0
     - 负数相加：-2 + 1 = -1
     - 边界值测试：Integer.MAX_VALUE - 1 + 1 = Integer.MAX_VALUE

2. Issue #2: 项目中需要新增获取系统运行cpu核数的方法
   - 新增 RuntimeUtils 工具类
   - 实现 getAvailableProcessors() 方法获取CPU核心数
   - 添加单元测试验证：
     - 确保返回值大于0
     - 确保返回值与系统实际报告的值一致

修复分支：fix/issue-1-2

请检查代码并合并，谢谢！